### PR TITLE
Initial commit

### DIFF
--- a/src/Feature/ScrollablePdoResult/Result.php
+++ b/src/Feature/ScrollablePdoResult/Result.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Db\Feature\ScrollablePdoResult;
+
+use Laminas\Db\Adapter\Driver\Pdo;
+use Laminas\Db\Exception\InvalidArgumentException;
+
+use function get_debug_type;
+use function in_array;
+use function sprintf;
+
+class Result extends Pdo\Result
+{
+    private const ALLOWED_MODES = [
+        self::STATEMENT_MODE_SCROLLABLE,
+        self::STATEMENT_MODE_FORWARD
+    ];
+
+    public function setStatementMode(string $mode): void
+    {
+        if (! in_array($mode, self::ALLOWED_MODES)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    '$mode must be one of %s::ALLOWED_MODES received: %s',
+                    get_debug_type($this),
+                    $mode
+                ),
+            );
+        }
+        $this->statementMode = $mode;
+    }
+}

--- a/src/Feature/ScrollablePdoResultFeature.php
+++ b/src/Feature/ScrollablePdoResultFeature.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Db\Feature;
+
+use Laminas\Db\Adapter\Driver\Pdo\Pdo as PdoAdapter;
+use Laminas\Db\TableGateway\Feature\AbstractFeature;
+
+use PDO;
+
+class ScrollablePdoResultFeature extends AbstractFeature
+{
+    public function preInitialize()
+    {
+        /** @var PdoAdapter */
+        $driver = $this->tableGateway->getAdapter()->getDriver();
+        if (! $driver instanceof PdoAdapter) {
+            return;
+        }
+        $resultPrototype = new ScrollablePdoResult\Result();
+        $resultPrototype->setStatementMode(
+            ScrollablePdoResult\Result::STATEMENT_MODE_SCROLLABLE
+        );
+        $driver->registerResultPrototype($resultPrototype);
+        /** @var PDO */
+        $resource = $driver->getConnection()->getResource();
+        $resource->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description
Provides a mechanism for setting the Result statement mode.  

- Are you adding something the library currently does not support?
Yes

  - Why should it be added?
   This allows the internal pointer to be reset to prevent "fast forward only" errors when passing ResultSets to laminas view partialLoop helpers among other use cases.
  - What will it enable?
  See above
  - How will the code be used?
  Simply add the "feature" to a TableGateway instance as a feature when initializing the instance.

